### PR TITLE
add headline for static response examples and links in example overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Press `CTRL+C` to exit.
 * [Query Parameter Manipulation](query/README.md)
 * [Sending JSON Content](sending-json/README.md)
 * [Sending Form Content](sending-form/README.md)
+* [Redirects](static-responses/README.md)
 
 ### Authorization & Authentication
 
@@ -70,10 +71,12 @@ Press `CTRL+C` to exit.
 * [OAuth2 Client Credentials Flow](oauth2-client-credentials/README.md)
 * [Single-Sign-On with SAML](saml/README.md)
 * [Error Handling for Access Controls](error-handling-ba/README.md)
+* [Userinfo Endpoint](static-responses/README.md)
 
 ### Running Couper
 
 * [Environment Variables](env-var/README.md)
+* [Emitting Environment Variables](static-responses/README.md)
 * [Using docker-compose](docker-compose/README.md)
 * [Kubernetes](kubernetes-configuration/README.md)
 * [Linking Docker Containers](linking-docker-containers/README.md)

--- a/static-responses/README.md
+++ b/static-responses/README.md
@@ -4,6 +4,8 @@ There are situations where no backend requests are sent for an endpoint.
 Nevertheless, a response is needed. So a `response` block can exist in an
 `endpoint` block without any `proxy` or `request` blocks.
 
+## Example 1: Redirects
+
 Consider the following example, in which the client is instructed to perform a
 redirect via a `301` status code and a `location` header specifying the
 redirect target:
@@ -34,9 +36,9 @@ Location: /app/
 
 ```
 
----
+## Example 2: _Userinfo_ endpoint
 
-Another example is a simple userinfo endpoint, similar to the one defined by
+Another example is a simple _userinfo_ endpoint, similar to the one defined by
 [OpenID Connect](https://openid.net/specs/openid-connect-core-1_0.html#UserInfo).
 The endpoint is protected by the "JWTToken" access control. The token claims
 are reflected to the client.
@@ -70,7 +72,7 @@ $ curl -H "Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJzdWIiOi
 }
 ```
 
----
+## Example 3: Environment variables
 
 As a third example we create a simple configuration endpoint that
 emits some


### PR DESCRIPTION
Since "Static Responses" is the solution and not the problem I added headlines to the static response examples and list them at the example overview. This should make it more easy to find answers to how to implement redirects, if we support userinfo endpoints and how to emit env vars with Couper.  