### PR TITLE
add docker-compose pull in example readme 

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ cd simple-fileserving
 and run
 
 ```sh
-docker-compose up
+docker-compose pull && docker-compose up
 ```
 
 Press `CTRL+C` to exit.


### PR DESCRIPTION
to avoid broken examples due to outdated Couper versions