### PR TITLE
replace old token source default

### DIFF
--- a/backend-authorization-oauth2/resource-server/couper.hcl
+++ b/backend-authorization-oauth2/resource-server/couper.hcl
@@ -14,6 +14,6 @@ definitions {
   jwt "token" {
     signature_algorithm = "HS256"
     key = "$eCr3T"
-    header = "Authorization"
+    bearer = true
   }
 }

--- a/jwt-access-control/README.md
+++ b/jwt-access-control/README.md
@@ -126,7 +126,7 @@ All we need is:
 ```hcl
 definitions {
   jwt "JWTToken" {
-    header = "Authorization"
+    bearer = true
     signature_algorithm = "RS256"
     key_file = "pub.pem"
   }
@@ -378,7 +378,7 @@ If the tokens are created by a token provider, e.g. an OAuth2 authorization serv
 
 ```hcl
   jwt "JWTToken" {
-    header = "Authorization"
+    bearer = true
     # signature_algorithm = "RS256"
     # key_file = "pub.pem"
     jwks_url = "https://my-authorization-server.com/jwks.json"

--- a/jwt-access-control/couper.hcl
+++ b/jwt-access-control/couper.hcl
@@ -15,7 +15,7 @@ server {
 
 definitions {
   jwt "JWTToken" {
-    header = "Authorization"
+    bearer = true
     # header = "API-Token"
     # cookie = "token"
     # token_value = request.form_body.token[0]


### PR DESCRIPTION
replaced old token source default (`header = "Authorization"`) with new (`bearer = true`)
see https://github.com/coupergateway/couper/pull/724

to be merged after couper release?